### PR TITLE
Fix to track APL svn r1521: PrintBuffer::get_height() -> get_row_count()

### DIFF
--- a/src/edif.cc
+++ b/src/edif.cc
@@ -233,7 +233,7 @@ get_var (const char *fn, const char *base, Value_P B, Shape &shape,
     
 	  ofstream tfile;
 	  tfile.open (fn, ios::out);
-	  loop (l, pb.get_height ()) {
+	  loop (l, pb.get_row_count ()) {
 	    UCS_string line = pb.get_line (l);
 	    /***
 	      pad char = APL character:  ⎕ (U+EEFB)


### PR DESCRIPTION
This method was renamed in GNU APL svn r1521, Feb 2 2022.